### PR TITLE
feat: pass index and samples count to callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function mark(label, samples, callback) {
   const [μs, ms, sec] = [10n ** 3n, 10n ** 6n, 10n ** 9n];
   const start = getTime();
   for (let i = 0; i < samples; i++) {
-    let val = callback({ i, samples });
+    let val = callback(i);
     if (val instanceof Promise) await val;
   }
   const end = getTime();

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function mark(label, samples, callback) {
   const [μs, ms, sec] = [10n ** 3n, 10n ** 6n, 10n ** 9n];
   const start = getTime();
   for (let i = 0; i < samples; i++) {
-    let val = callback();
+    let val = callback({ i, samples });
     if (val instanceof Promise) await val;
   }
   const end = getTime();


### PR DESCRIPTION
While adding fixtures to https://github.com/ethereumjs/ethereumjs-monorepo/pull/2128 and rewriting some tests to reflect actual production use more realistically I noticed that it would be handy to have access to the index of the samples execution and also the samples count. This would allow to write benchmarks like this:

```ts
  await mark(`Checkpointing: 100 iterations`, 100, async ({ i }) => {
    trie.checkpoint()
    await trie.put(keys[i], vals[i])
    await trie.commit()
  })
```

Where `keys` and `vals` are now fixtures rather than generating them at runtime. Without this PR you would need maintain a separate index count that will reflect the same number that the runner here already has available to it.